### PR TITLE
Pin nixpkgs to a recent-ish 18.09

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "default" }:
+{ nixpkgs ? import ./nixpkgs.nix, compiler ? "default" }:
 
 let
   inherit (nixpkgs) pkgs;

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,7 @@
+let
+  nixpkgs-source = builtins.fetchTarball {
+    url = "https://releases.nixos.org/nixos/18.09/nixos-18.09.1922.97e0d53d669/nixexprs.tar.xz";
+    sha256 = "0jl72zcsap4xjh483mjyvhmim45ghklw3pqr8mp0khwvh83422z6";
+  };
+in
+  import nixpkgs-source {}

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "default"}:
+{ nixpkgs ? import ./nixpkgs.nix, compiler ? "default"}:
 let
   inherit (nixpkgs) pkgs;
   drv = import ./default.nix { inherit nixpkgs compiler; };


### PR DESCRIPTION
This might work

```
bradparker@Brads-MacBook-Pro [pin-nixpkgs]
~/code/stacktrace/fp-course » readlink $(readlink $(which ghc))
/nix/store/6qax61v86ajcky9higgqlnxvvy43j8md-ghc-8.4.4/bin/ghc
bradparker@Brads-MacBook-Pro [pin-nixpkgs]
~/code/stacktrace/fp-course » nix-shell
bradparker@Brads-MacBook-Pro [nix:ghc-shell-for-course-0.1.4][pin-nixpkgs]
~/code/stacktrace/fp-course » which ghc
/nix/store/kikbj08p4m6dviqa9xkq10i9v0nirjln-ghc-8.4.4-with-packages/bin/ghc
```