### PR TITLE
Fix ghci loading & StateT Num Constraint

### DIFF
--- a/src/Course/StateT.hs
+++ b/src/Course/StateT.hs
@@ -207,7 +207,7 @@ distinct' =
 -- >>> distinctF $ listh [1,2,3,2,1,101]
 -- Empty
 distinctF ::
-  Ord a =>
+  (Num a, Ord a) =>
   List a
   -> Optional (List a)
 distinctF =

--- a/test/Course/MoreParserTest.hs
+++ b/test/Course/MoreParserTest.hs
@@ -7,6 +7,7 @@ module Course.MoreParserTest where
 import           Test.Tasty            (TestTree, testGroup)
 import           Test.Tasty.HUnit      (testCase, (@?=), assertBool)
 
+import           Course.Applicative    ((>>), return)
 import           Course.Core
 import           Course.List           (List (..))
 import           Course.Parser

--- a/test/Course/ParserTest.hs
+++ b/test/Course/ParserTest.hs
@@ -7,7 +7,7 @@ module Course.ParserTest where
 import           Test.Tasty            (TestTree, testGroup)
 import           Test.Tasty.HUnit      (testCase, (@?=), assertBool)
 
-import           Course.Applicative    (pure, (<*>), (*>))
+import           Course.Applicative    (pure, return, (>>), (<*>), (*>))
 import           Course.Core
 import           Course.List           (List (..))
 import           Course.Monad          ((=<<))


### PR DESCRIPTION
Without importing `(>>)` and `return` from `Course.Applicative` you can't load the `Parser` and `MoreParser` tests in ghci. We now import these functions in those test files which solves this problem (although you will get a `cabal build` warning about unused imports).

Also, we'll need a num contraint on the `distinctF` function in `StateT`. I think we lost this after merging the data61 master branch.